### PR TITLE
Added support for account deletion

### DIFF
--- a/api-test/test/v0/account.test.js
+++ b/api-test/test/v0/account.test.js
@@ -62,45 +62,8 @@ describe('Account operations', () => {
       .get('/account/{id}')
       .withPathParams('id', '$S{AccountID}')
       .expectJson('data.attributes.name', 'Monthly rent');
-  });
-
-  it('Hide account', async () => {
-    await e2e.step('Hide account')
-      .spec('delete')
-      .delete('/account/{id}')
-      .withPathParams('id', '$S{AccountID}');
-  });
-
-  it('Hidden account is in non-filtered account lists', async () => {
-    await e2e.step('Hidden account is in non-filtered account lists')
-      .spec('read')
-      .get('/account')
-      .expectJsonMatch('data[*].id', expression('$S{AccountID}', '$V.includes($S{AccountID})'));
-  });
-
-  it('Hidden account is in hidden accounts list', async () => {
-    await e2e.step('Hidden account is in hidden accounts list')
-      .spec('read')
-      .get('/account')
-      .withQueryParams({ filter: '%7B%22hidden%22%3A%22true%22%7D' })
-      .expectJsonMatch('data[*].id', expression('$S{AccountID}', '$V.includes($S{AccountID})'));
-  });
-
-  it('Hidden account is not in active accounts list', async () => {
-    await e2e.step('Hidden account is not in active accounts list')
-      .spec('read')
-      .get('/account')
-      .withQueryParams({ filter: '%7B%22hidden%22%3A%22false%22%7D' })
-      .expectJsonMatch('data[*].id', expression('$S{AccountID}', '!$V.includes($S{AccountID})'));
-  });
-
-  it('Specific filtering ignores hidden flag', async () => {
-    await e2e.step('Specific filtering ignores hidden flag')
-      .spec('read')
-      .get('/account')
-      .withQueryParams({ filter: '%7B%22name%22%3A%22Monthly%20rent%22%7D' })
-      .expectJsonMatch('data[*].id', expression('$S{AccountID}', '$V.includes($S{AccountID})'));
 
     await e2e.cleanup();
   });
+
 });

--- a/api-test/test/v1/account.test.js
+++ b/api-test/test/v1/account.test.js
@@ -64,10 +64,19 @@ describe('Account operations', () => {
     });
 
     it('Hide account', async () => {
+
         await e2e.step('Hide account')
-            .spec('delete')
-            .delete('/accounts/{id}')
-            .withPathParams('id', '$S{AccountID}');
+          .spec('update')
+          .put('/accounts/{id}')
+          .withPathParams('id', '$S{AccountID}')
+          .withJson({
+              '@DATA:TEMPLATE@': 'Account:Expense:V1',
+              '@OVERRIDES@': {
+                  name: 'Monthly rent', //For specific filtering
+                  hidden: true
+              }
+          })
+          .expectJson('hidden', true);
     });
 
     it('Hidden account is in non-filtered account lists', async () => {

--- a/api-test/test/v1/account_deletion.test.js
+++ b/api-test/test/v1/account_deletion.test.js
@@ -1,0 +1,66 @@
+const pactum = require('pactum');
+const { expression } = require('pactum-matchers');
+const { createAccountForTransaction } = require('./transaction.handler');
+
+describe('Account deletion clearance', () => {
+  const e2e = pactum.e2e('Account deletion clearance');
+
+  it('Create Account and add Ops', async () => {
+    await createAccountForTransaction(e2e);
+
+    await e2e.step('Create transaction')
+      .spec('Create Transaction', { '@DATA:TEMPLATE@': 'Transaction:Rent:V1' })
+      .stores('TransactionID', 'id')
+      .expectJsonLike({'@DATA:TEMPLATE@': 'Transaction:Rent:V1'});
+  });
+
+  it('Account with operations is not deletable', async () => {
+    await e2e.step('Read account status')
+      .spec('read')
+      .get('/accounts/{id}/status')
+      .withPathParams('id', '$S{AssetAccountID}')
+      .expectJson('deletable', false);
+  });
+
+  it('Deletion of used account fails', async () => {
+    await e2e.step('Delete used account')
+      .spec()
+      .withHeaders('Content-Type', 'application/vnd.mdg+json;version=1')
+      .delete('/accounts/{id}')
+      .withPathParams('id', '$S{AssetAccountID}')
+      .expectStatus(409);
+  });
+
+  it('Delete transaction', async () => {
+    await e2e.step('Delete transaction')
+      .spec('delete')
+      .delete('/transactions/{id}')
+      .withPathParams('id', '$S{TransactionID}');
+  });
+
+  it('Account without operations is deletable', async () => {
+    await e2e.step('Read account status')
+      .spec('read')
+      .get('/accounts/{id}/status')
+      .withPathParams('id', '$S{AssetAccountID}')
+      .expectJson('deletable', true);
+  });
+
+  it('Deletion of unused account succeeds', async () => {
+    await e2e.step('Delete used account')
+      .spec()
+      .withHeaders('Content-Type', 'application/vnd.mdg+json;version=1')
+      .delete('/accounts/{id}')
+      .withPathParams('id', '$S{AssetAccountID}')
+      .expectStatus(204);
+  });
+
+  it('Deleted account is not in non-filtered account lists', async () => {
+    await e2e.step('Deleted account is not in non-filtered account lists')
+      .spec('read')
+      .get('/accounts')
+      .expectJsonMatch('accounts[*].id', expression('$S{AccountID}', '!$V.includes($S{AssetAccountID})'));
+
+    await e2e.cleanup();
+  });
+});

--- a/backend/src/main/java/org/akashihi/mdg/api/v1/AccountController.java
+++ b/backend/src/main/java/org/akashihi/mdg/api/v1/AccountController.java
@@ -2,6 +2,7 @@ package org.akashihi.mdg.api.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.akashihi.mdg.api.v1.dto.AccountStatus;
 import org.akashihi.mdg.api.v1.dto.Accounts;
 import org.akashihi.mdg.api.v1.dto.CategoryTree;
 import org.akashihi.mdg.api.v1.dto.CategoryTreeEntry;
@@ -106,5 +107,10 @@ public class AccountController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void delete(@PathVariable("id") Long id) {
         accountService.delete(id);
+    }
+
+    @GetMapping(value = "/accounts/{id}/status", produces = "application/vnd.mdg+json;version=1")
+    AccountStatus getStatus(@PathVariable("id") Long id) {
+        return new AccountStatus(id, accountService.isDeletable(id));
     }
 }

--- a/backend/src/main/java/org/akashihi/mdg/api/v1/dto/AccountStatus.java
+++ b/backend/src/main/java/org/akashihi/mdg/api/v1/dto/AccountStatus.java
@@ -1,0 +1,3 @@
+package org.akashihi.mdg.api.v1.dto;
+
+public record AccountStatus(Long id, Boolean deletable) { }

--- a/backend/src/main/java/org/akashihi/mdg/dao/OperationRepository.java
+++ b/backend/src/main/java/org/akashihi/mdg/dao/OperationRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
+
 public interface OperationRepository extends JpaRepository<Operation, Long> {
     @Modifying
     @Query(nativeQuery = true, value = "DELETE FROM operation where tx_id = ?1")
     void deleteOperationsForTransaction(Long txId);
+
+    @Query(nativeQuery = true, value = "SELECT DISTINCT TRUE FROM operation WHERE account_id=?1")
+    Optional<Boolean> doOperationsExistForAccount(Long accountId);
 }

--- a/backend/src/main/java/org/akashihi/mdg/service/AccountService.java
+++ b/backend/src/main/java/org/akashihi/mdg/service/AccountService.java
@@ -6,6 +6,7 @@ import org.akashihi.mdg.api.v1.RestException;
 import org.akashihi.mdg.dao.AccountRepository;
 import org.akashihi.mdg.dao.CategoryRepository;
 import org.akashihi.mdg.dao.CurrencyRepository;
+import org.akashihi.mdg.dao.OperationRepository;
 import org.akashihi.mdg.entity.Account;
 import org.akashihi.mdg.entity.AccountType;
 import org.springframework.data.domain.Sort;
@@ -30,6 +31,7 @@ public class AccountService {
     private final TransactionService transactionService;
     private final SettingService settingService;
     private final RateService rateService;
+    private final OperationRepository operationRepository;
 
     protected Account applyBalance(Account a) {
         var balance = accountRepository.getBalance(a.getId()).orElse(BigDecimal.ZERO);
@@ -149,5 +151,10 @@ public class AccountService {
         var account = accountRepository.findById(id).orElseThrow(() -> new RestException("ACCOUNT_NOT_FOUND", 404, "/accounts/%d".formatted(id)));
         account.setHidden(true);
         accountRepository.save(account);
+    }
+
+    @Transactional public Boolean isDeletable(Long id) {
+        var account = accountRepository.findById(id).orElseThrow(() -> new RestException("ACCOUNT_NOT_FOUND", 404, "/accounts/%d/status".formatted(id)));
+        return !operationRepository.doOperationsExistForAccount(account.getId()).orElse(false);
     }
 }

--- a/backend/src/main/java/org/akashihi/mdg/service/AccountService.java
+++ b/backend/src/main/java/org/akashihi/mdg/service/AccountService.java
@@ -149,8 +149,10 @@ public class AccountService {
     @Transactional
     public void delete(Long id) {
         var account = accountRepository.findById(id).orElseThrow(() -> new RestException("ACCOUNT_NOT_FOUND", 404, "/accounts/%d".formatted(id)));
-        account.setHidden(true);
-        accountRepository.save(account);
+        if (!isDeletable(account.getId())) {
+            throw new RestException("ACCOUNT_IN_USE", 409, "/accounts/%d".formatted(id));
+        }
+        accountRepository.delete(account);
     }
 
     @Transactional public Boolean isDeletable(Long id) {

--- a/backend/src/main/resources/conf/liquibase/26-accountdeletionerror.sql
+++ b/backend/src/main/resources/conf/liquibase/26-accountdeletionerror.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+
+--changeset akashihi:1
+
+INSERT INTO ERROR VALUES('ACCOUNT_IN_USE', '409', 'Used accounts can not be deleted', 'It is forbidden to remove accounts which are participating in the operations');
+
+--rollback DELETE FROM ERROR WHERE CODE='ACCOUNT_IN_USE';
+
+--changeset akashihi:2
+ALTER TABLE budgetentry DROP CONSTRAINT budgetentry_account_id_fkey;
+
+ALTER TABLE budgetentry ADD FOREIGN KEY (account_id) REFERENCES account ON DELETE CASCADE;
+
+--rollback ALTER TABLE budgetentry DROP CONSTRAINT budgetentry_account_id_fkey;
+--rollback ALTER TABLE budgetentry ADD FOREIGN KEY (account_id) REFERENCES account;

--- a/backend/src/main/resources/conf/liquibase/db.changelog-master.yaml
+++ b/backend/src/main/resources/conf/liquibase/db.changelog-master.yaml
@@ -49,4 +49,6 @@ databaseChangeLog:
       file: conf/liquibase/24-mqt_refresh.sql
   - include:
       file: conf/liquibase/25-nonegativebudgetentry.sql
+  - include:
+      file: conf/liquibase/26-accountdeletionerror.sql
 

--- a/docs/mdg.apib
+++ b/docs/mdg.apib
@@ -252,7 +252,7 @@ Only `hidden`, `name`, `category_id`, `favorite` and `operational` fields could 
     
 ### Delete an account [DELETE]
 
-Actually accounts are immortal, deleting an account puts a 'hidden' flag on it.
+Only accounts without operations will be deleted. If there exists any operations, referring to the account, an error will be returned instead. Check the `status` object below.
 
 + Response 204
 
@@ -331,6 +331,20 @@ Accounts with attribute 'hidden' equal to 'true' are shown if no filter is speci
             ]    
         }
 
+## Account status [/accounts/{account_id}/status]
+
++ parameters
+    + account_id: 2 (number, required) - ID of an account in form of integer
+
++ Attributes
+    + id: 2 (number, required) - Account id
+    + deletable: false (boolean, required) - Whether account could be deleted or not.
+
+### Retrieve account status [GET]
+
++ Response 201 (application/vnd.mdg+json;version=1)
+    + Attributes (Account status)
+    
 # Group Tags
 
 Transaction tags dictionary. Each tag is an unique, case-insensitive string.

--- a/frontend/src/js/actions/AccountActions.ts
+++ b/frontend/src/js/actions/AccountActions.ts
@@ -83,32 +83,20 @@ export function setOperational(account: Account, operational: boolean) {
     };
 }
 
-export function revealAccount(account: Account) {
+function updateHidden(account: Account, value: boolean) {
     return dispatch => {
         const updatedAccount: Account = produce(draft => {
-            draft.hidden = false;
+            draft.hidden = value;
         })(account);
         dispatch(updateAccount(updatedAccount));
     };
 }
+export function revealAccount(account: Account) {
+    return updateHidden(account, false);
+}
 
 export function hideAccount(account: Account) {
-    return dispatch => {
-        dispatch({ type: AccountActionType.AccountsLoad, payload: [] });
-
-        const url = `/api/accounts/${account.id}`;
-        const method = 'DELETE';
-
-        fetch(url, {
-            method,
-            headers: {
-                'Content-Type': 'application/vnd.mdg+json;version=1',
-            },
-        })
-            .then(processApiResponse)
-            .then(() => dispatch(loadAccountList()))
-            .catch(() => dispatch(loadAccountList()));
-    };
+    return updateHidden(account, true);
 }
 
 export function updateAccount(account: Partial<Account>) {
@@ -141,6 +129,25 @@ export function updateAccount(account: Partial<Account>) {
                     dispatch(loadSelectedBudget(selectedBudgetId));
                 }
             })
+            .catch(() => dispatch(loadAccountList()));
+    };
+}
+
+export function deleteAccount(account: Account) {
+    return dispatch => {
+        dispatch({ type: AccountActionType.AccountsLoad, payload: [] });
+
+        const url = `/api/accounts/${account.id}`;
+        const method = 'DELETE';
+
+        fetch(url, {
+            method,
+            headers: {
+                'Content-Type': 'application/vnd.mdg+json;version=1',
+            },
+        })
+            .then(processApiResponse)
+            .then(() => dispatch(loadAccountList()))
             .catch(() => dispatch(loadAccountList()));
     };
 }

--- a/frontend/src/js/components/account/AccountDialog.tsx
+++ b/frontend/src/js/components/account/AccountDialog.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import { produce } from 'immer';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
+import LoadingButton from '@mui/lab/LoadingButton';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { TextField, Switch } from 'formik-mui';
 import MenuItem from '@mui/material/MenuItem';
@@ -12,8 +13,24 @@ import * as Yup from 'yup';
 import { AccountDialogProps } from '../../containers/AccountEditor';
 import { mapCategoryListToMenu } from '../../util/CategoryUtils';
 import { Account } from '../../models/Account';
+import {processApiResponse} from "../../util/ApiUtils";
 
 function AccountDialog(props: AccountDialogProps) {
+    const [loading, setLoading] = useState<boolean>(true);
+    const [deletable, setDeletable] = useState<boolean>(false);
+
+    useEffect(() => {
+        const url = `/api/accounts/${props.account.id}/status`;
+
+        setLoading(true);
+        fetch(url)
+            .then(processApiResponse)
+            .then((data) => {
+                setDeletable(data.deletable)
+                setLoading(false);
+            });
+    }, [props.account.id]);
+
     const onSubmit = (values: Account) => {
         props.close();
 
@@ -158,6 +175,10 @@ function AccountDialog(props: AccountDialogProps) {
                             />
                         </DialogContent>
                         <DialogActions>
+                            <LoadingButton color="error" disabled={!deletable} loading={loading} onClick={props.close}>
+                                Delete
+                            </LoadingButton>
+                            <div style={{flex: '1 0 0'}} />
                             <Button color="primary" disabled={isSubmitting} onClick={submitForm}>
                                 Save
                             </Button>

--- a/frontend/src/js/components/account/AccountDialog.tsx
+++ b/frontend/src/js/components/account/AccountDialog.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import { produce } from 'immer';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
@@ -13,7 +13,7 @@ import * as Yup from 'yup';
 import { AccountDialogProps } from '../../containers/AccountEditor';
 import { mapCategoryListToMenu } from '../../util/CategoryUtils';
 import { Account } from '../../models/Account';
-import {processApiResponse} from "../../util/ApiUtils";
+import { processApiResponse } from '../../util/ApiUtils';
 
 function AccountDialog(props: AccountDialogProps) {
     const [loading, setLoading] = useState<boolean>(true);
@@ -25,8 +25,8 @@ function AccountDialog(props: AccountDialogProps) {
         setLoading(true);
         fetch(url)
             .then(processApiResponse)
-            .then((data) => {
-                setDeletable(data.deletable)
+            .then(data => {
+                setDeletable(data.deletable);
                 setLoading(false);
             });
     }, [props.account.id]);
@@ -175,10 +175,17 @@ function AccountDialog(props: AccountDialogProps) {
                             />
                         </DialogContent>
                         <DialogActions>
-                            <LoadingButton color="error" disabled={!deletable} loading={loading} onClick={props.close}>
+                            <LoadingButton
+                                color="error"
+                                disabled={!deletable}
+                                loading={loading}
+                                onClick={() => {
+                                    props.close();
+                                    props.deleteAccount(props.account);
+                                }}>
                                 Delete
                             </LoadingButton>
-                            <div style={{flex: '1 0 0'}} />
+                            <div style={{ flex: '1 0 0' }} />
                             <Button color="primary" disabled={isSubmitting} onClick={submitForm}>
                                 Save
                             </Button>

--- a/frontend/src/js/containers/AccountEditor.ts
+++ b/frontend/src/js/containers/AccountEditor.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import AccountDialog from '../components/account/AccountDialog';
-import { updateAccount } from '../actions/AccountActions';
+import { updateAccount, deleteAccount } from '../actions/AccountActions';
 import { Account } from '../models/Account';
 import { RootState } from '../reducers/rootReducer';
 import Category from '../models/Category';
@@ -35,7 +35,7 @@ const mapStateToProps = (state: RootState, ownProps: AccountEditorProps): Accoun
     };
 };
 
-const mapDispatchToProps = { updateAccount };
+const mapDispatchToProps = { updateAccount, deleteAccount };
 
 export type AccountDialogProps = AccountEditorState & typeof mapDispatchToProps;
 


### PR DESCRIPTION
Closes #1 

It is already possible to change currency for non-assets accounts without any restrictions, but currency change for the asset accounts is not supported and will not be supported. Instead this change allows removal of 'unused' accounts, which has no associated operations. 

Unfortunately it also deletes account specific budget information, so should be used with a caution.